### PR TITLE
11483 Misleading Dialog Title

### DIFF
--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -581,7 +581,7 @@ Actions = {
 
 		let dialogParams = {
 			title: "New Workspace",
-			question: "The workspace \"" + workspaceName + "\" already exists. A new workspace will be created.",
+			question: "The workspace \"" + workspaceName + "\" already exists. A new workspace with a modified name will be created.",
 			affirmativeResponseLabel: "OK",
 			showNegativeButton: false
 		};


### PR DESCRIPTION
**Resolves issue [11483](https://chartiq.kanbanize.com/ctrl_board/18/cards/11483/details)**

**Description of change**
- Fixed a dialog title so that it's no longer ambiguous as to what happens when you name a New Workspace the same as an existing workspace.
- Commit is from Nicolai (my bad, Mike).

**Description of testing**
1. Create a New Workspace and name it the same as an existing workspace
2. A dialog will pop up with the title "New Workspace". (If it says "Overwrite Workspace?", then it didn't work.)

