### PR TITLE
14512 TilingStop on tabbing cancel

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -254,8 +254,9 @@ class WindowTitleBar extends React.Component {
 		//Add an event listener to hide the drag-handler when tiling is started
 		FSBL.Clients.RouterClient.addListener("DockingService.startTilingOrTabbing", this.onTilingStart);
 
-		//Add an event listener to show the drag-handler when tiling is stopped
+		//Add an event listener to show the drag-handler when tiling is stopped or cancelled
 		FSBL.Clients.RouterClient.addListener("DockingService.stopTilingOrTabbing", this.onTilingStop);
+		FSBL.Clients.RouterClient.addListener("DockingService.cancelTilingOrTabbing", this.onTilingStop);
 	}
 
 	/**


### PR DESCRIPTION
fix: #id [14512]

Kanban link

Fixed stopTilingOrTabbing
stopTilingOrTabbing had an error in how it was calling window bounds. However, after digging through how this is called and potential ramifications, there was no reason for it to be doing so.

This function has been stripped back. With how this function is called, "allowDropOnSelf" is set to true (via config) from drop events on Finsemble components. With the front end guard being right, we don't need to know if the "pointIsInBox", we just need to know if there's a drop callback to execute.

So, we transmit the router messages, and if the stopTabbingOrTiling event happened on a window that allows it, we run the callback, i.e. the drop event for that component. This should help tighten up the handling of tabs.

Description of testing
Markdown will convert the 1s to the appropriate number.

Open a Welcome Component
Try to drag the tab of a window into it's own body.
Verify that the window can still be moved, tabbed into other windows, etc...
In general, play with tabbing and verify that everything works as designed.