### PR TITLE
[16445] Adding oauthResponse.html back

### DIFF
--- a/src-built-in/components/authentication/README.md
+++ b/src-built-in/components/authentication/README.md
@@ -1,10 +1,11 @@
-## Authentication
+
+# Authentication
 
 This is the authentication login screen you see when Finsemble starts with authentication enabled.
 
-### Overview
+## Overview
 
 See [Enabling Authentication](https://documentation.chartiq.com/finsemble/tutorial-Authentication.html) for an overview.
 
-### What it looks like
+## What it looks like
 ![](./screenshot.png)

--- a/src-built-in/components/authentication/oauthResponse.html
+++ b/src-built-in/components/authentication/oauthResponse.html
@@ -132,9 +132,5 @@
 		</div>
 	</div>
 	<div id="error"></div>
-
-	<script src="https://apis.google.com/js/api.js"></script>
-
-
 </body>
 </html>

--- a/src-built-in/components/authentication/oauthResponse.html
+++ b/src-built-in/components/authentication/oauthResponse.html
@@ -16,8 +16,6 @@
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script>
-		var urlParams = new URLSearchParams(window.location.search);
-		console.log('oauthresponse', urlParams)
 		/** Class for handling oAuth returns */
 		class HandleOauth {
 			constructor() {
@@ -68,10 +66,8 @@
 		const OauthClient = new HandleOauth();
 
 		FSBL.Clients.AuthenticationClient.completeOAUTH(null, null, (err, response) => {
-			
-			console.log('AuthenticationClient.completeOAUTH', response)
 			if (err) {
-				OauthClient.showError('x');
+				OauthClient.showError(err);
 			} else {
 				const credentials = response;
 				OauthClient.runBusinessLogic(credentials, () => {
@@ -131,14 +127,12 @@
 	</style>
 	<div class="fsbl-auth-top">
 		<img class="fsbl-logo" src="../../assets/img/ciq-banner-black-100x25.png" width="100" height="25">
-		<div class="fsbl-close" id="FSBL-close" onclick="closeThisWindow()">
+		<div class="fsbl-close" id="FSBL-close" onclick="OauthClient.closeThisWindow()">
 			<i class="ff-close" style=color:#666></i>
 		</div>
 	</div>
 	<div id="error"></div>
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 
-	<script src="authentication.js"></script>
 	<script src="https://apis.google.com/js/api.js"></script>
 
 

--- a/src-built-in/components/authentication/oauthResponse.html
+++ b/src-built-in/components/authentication/oauthResponse.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+<!--
+    /*!
+    * Copyright 2017 by ChartIQ, Inc.
+    * All rights reserved.
+    */
+	OAUTH Authentication example. This example uses Google as a OpenID Provider (OP).
+
+-->
+
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	<title>Oauth Authentification</title>
+	<meta name="description" content="">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<script>
+		function closeThisWindow(){
+			// When we close this window, if the user isn't logged in then it must mean we
+			// were using OAUTH to log in, and it failed, so shut down the entire app. Otherwise
+			// we were just using it to authenticate a client, in which case we just want to close
+			// this window but keep Finsemble running.
+			FSBL.Clients.AuthenticationClient.getCurrentCredentials(function(err, credentials){
+				if(!credentials){
+					FSBL.shutdownApplication();
+				}else{
+					fin.desktop.Window.getCurrent().close(true);
+				}
+			});
+		}
+
+		function showError(reason){
+			$("#error").text("Oauth Failed: " + reason);
+		}
+
+		function runBusinessLogic(credentials, cb){
+			// Run your business logic here. For instance, fetch dynamic config based on the user's credentials.
+			cb();
+		};
+
+		FSBL.Clients.AuthenticationClient.completeOAUTH(null, function(err, response){
+			if(err){
+				showError(err);
+			}else{
+				var credentials=response;
+				runBusinessLogic(credentials, function(){
+					// In the special case of "startup" then we publish the authorization, which releases Finsemble and lets is start
+					if (credentials.config.name === "startup") {
+						// "sub" is the user ID provided by the OP. Not all OP's support this. If not supported, then we just set the user to the access token.
+						var user = credentials.sub;
+						if (!user) user = credentials.access_token;
+						// Finish the authentication process
+						FSBL.Clients.RouterClient.transmit("AuthenticationService.authorization", { user: user, credentials: credentials });
+					}
+					closeThisWindow();
+				});
+			}
+		});
+
+	</script>
+	<link href='https://fonts.googleapis.com/css?family=Roboto:400,700,500,100,300,400italic|Roboto+Condensed:400,700,300' rel='stylesheet'
+	type='text/css'>
+	<link rel="stylesheet" type="text/css" href="../../assets/css/finsemble.css">
+	<link rel="stylesheet" type="text/css" href="../../assets/css/font-finance.css">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
+</head>
+
+<body class="dialog">
+	<style>
+		.fsbl-auth-top {
+			display: flex;
+			justify-content: space-between;
+			height: 20px;
+			align-items: center;
+			padding: 10px 10px 5px 0px;
+		}
+
+		.fsbl-close {
+			cursor: pointer;
+			display: flex;
+			justify-content: flex-end;
+			align-items: flex-start;
+			flex-direction: column;
+			height: 100%;
+		}
+
+		#error {
+			text-align: center;
+			margin-top: 50px;
+		}
+
+		body {
+			background: white;
+			max-height: 442px;
+			max-width: 342px;
+		}
+
+	</style>
+	<div class="fsbl-auth-top">
+		<img class="fsbl-logo" src="../../assets/img/ciq-banner-black-100x25.png" width="100" height="25">
+		<div class="fsbl-close" id="FSBL-close" onclick="closeThisWindow()">
+			<i class="ff-close" style=color:#666></i>
+		</div>
+	</div>
+	<div id="error"></div>
+</body>
+</html>

--- a/src-built-in/components/authentication/oauthResponse.html
+++ b/src-built-in/components/authentication/oauthResponse.html
@@ -12,7 +12,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<title>Oauth Authentification</title>
+	<title>Oauth Authentication</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script>

--- a/src-built-in/components/authentication/oauthResponse.html
+++ b/src-built-in/components/authentication/oauthResponse.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
 <!--
-    /*!
-    * Copyright 2017 by ChartIQ, Inc.
+    /**
+    * Copyright 2019, ChartIQ, Inc.
     * All rights reserved.
-    */
+	*/
+	
 	OAUTH Authentication example. This example uses Google as a OpenID Provider (OP).
-
 -->
 
 <head>
@@ -16,54 +16,86 @@
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script>
-		function closeThisWindow(){
-			// When we close this window, if the user isn't logged in then it must mean we
-			// were using OAUTH to log in, and it failed, so shut down the entire app. Otherwise
-			// we were just using it to authenticate a client, in which case we just want to close
-			// this window but keep Finsemble running.
-			FSBL.Clients.AuthenticationClient.getCurrentCredentials(function(err, credentials){
-				if(!credentials){
-					FSBL.shutdownApplication();
-				}else{
-					fin.desktop.Window.getCurrent().close(true);
-				}
-			});
+		var urlParams = new URLSearchParams(window.location.search);
+		console.log('oauthresponse', urlParams)
+		/** Class for handling oAuth returns */
+		class HandleOauth {
+			constructor() {
+
+			}
+
+			/**
+			 *  closeThisWindow
+			 * 
+			 *  When we close this window, if the user isn't logged in then it must mean we
+			 *  were using OAUTH to log in, and it failed, so shut down the entire app. Otherwise
+			 *  we were just using it to authenticate a client, in which case we just want to close
+			 * this window but keep Finsemble running.
+			 */
+			closeThisWindow() {
+				FSBL.Clients.AuthenticationClient.getCurrentCredentials((err, credentials) => {
+					if (!credentials) {
+						FSBL.shutdownApplication();
+					} else {
+						FSBL.Clients.WindowClient.getCurrentWindow().close();
+					}
+				});
+			}
+		
+			/**
+			 * showError
+			 * 
+			 * @param {string} reason Textual representation of why the Oauth Process Failed
+			 */
+			showError(reason) {
+				document.querySelector("#error").innerHTML = `Oauth Failed: ${reason}`;
+			}
+
+			/**
+			 * runBusinessLogic
+			 * 
+			 * Run your oAuth business logic to handle the user's action
+			 * 
+			 * @param {object} credentials 
+			 * @param {function} cb The callback function to invoke when your custom logic has completed.
+			 */
+			runBusinessLogic(credentials, cb) {
+				// Run your custom  business logic here. For instance, fetch dynamic config based on the user's credentials.
+				cb();
+			}
 		}
 
-		function showError(reason){
-			$("#error").text("Oauth Failed: " + reason);
-		}
+		const OauthClient = new HandleOauth();
 
-		function runBusinessLogic(credentials, cb){
-			// Run your business logic here. For instance, fetch dynamic config based on the user's credentials.
-			cb();
-		};
-
-		FSBL.Clients.AuthenticationClient.completeOAUTH(null, function(err, response){
-			if(err){
-				showError(err);
-			}else{
-				var credentials=response;
-				runBusinessLogic(credentials, function(){
+		FSBL.Clients.AuthenticationClient.completeOAUTH(null, null, (err, response) => {
+			
+			console.log('AuthenticationClient.completeOAUTH', response)
+			if (err) {
+				OauthClient.showError('x');
+			} else {
+				const credentials = response;
+				OauthClient.runBusinessLogic(credentials, () => {
 					// In the special case of "startup" then we publish the authorization, which releases Finsemble and lets is start
 					if (credentials.config.name === "startup") {
 						// "sub" is the user ID provided by the OP. Not all OP's support this. If not supported, then we just set the user to the access token.
-						var user = credentials.sub;
-						if (!user) user = credentials.access_token;
+						const user = credentials.sub;
+						if (!user) {
+							user = credentials.access_token;
+						}
 						// Finish the authentication process
 						FSBL.Clients.RouterClient.transmit("AuthenticationService.authorization", { user: user, credentials: credentials });
 					}
-					closeThisWindow();
+					OauthClient.closeThisWindow();
 				});
 			}
 		});
+	
 
 	</script>
 	<link href='https://fonts.googleapis.com/css?family=Roboto:400,700,500,100,300,400italic|Roboto+Condensed:400,700,300' rel='stylesheet'
 	type='text/css'>
 	<link rel="stylesheet" type="text/css" href="../../assets/css/finsemble.css">
 	<link rel="stylesheet" type="text/css" href="../../assets/css/font-finance.css">
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
 </head>
 
 <body class="dialog">
@@ -104,5 +136,11 @@
 		</div>
 	</div>
 	<div id="error"></div>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+
+	<script src="authentication.js"></script>
+	<script src="https://apis.google.com/js/api.js"></script>
+
+
 </body>
 </html>


### PR DESCRIPTION
**fix: #id 16445**

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/21/cards/16445/details/)

**Description of change**

> The OAuth documentation references the oauthResponse.html file, but it doesn't exist in the seed. File does exist in the sales demo.

* Changes
  * Duplicated `finsemble-sales-demo/src/components/authentication/oauthResponse.html` to `finsemble-seed/src-built-in/components/authentication/oauthResponse.html`

**NOTE**: as using this requires a great deal of application-specific logic (what oAuth endpoints, what oAuth service, etc.) so testing will be involved. This heavily depends upon the client's implementation, so a skeleton of the process is provided below.

**Description of testing**

1. I followed [the authentication tutorial](https://documentation.chartiq.com/finsemble/tutorial-Authentication.html#oauth-2-0-openid). 
    1. For the purposes of testing, I included [googleapis](https://www.npmjs.com/package/googleapis) to handle the oAuth work for the server-side. If using Google, run `npm install googleapis`. Version tested was `^43.0.0`. This is implementation-specific and thus not included in `package.json`.
    1. `server/server.js` can be modified to accept an incoming `/authenticate` route for the `backchannel_endpoint`. As this contains secret keys, this must be server side. I have a secret gist for this with `server/server.js` and  `manifest-local.json` containing this code. Again, this is implementation-specific so code is not included in the PR.
1. Start Finsemble
    - [ ] oAuth window displays
    - [ ] Completing the auth flow displays:
       <img width="801" alt="Screen Shot 2019-10-02 at 3 26 36 PM" src="https://user-images.githubusercontent.com/55208294/66075588-f4809c80-e529-11e9-82ed-3bad43d8e1f0.png"> This displays the contents provided in `oauthResponse.html`

1. `x` out of the window
    - [ ] Electron quits with code `0`