### PR TITLE
fix: #id 28710 fix tab drag

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -198,7 +198,6 @@ export default class TabRegion extends React.Component {
         if (!identifier) return; // the dropped item is not a tab
         if (this.state.tabs.length === 1 && identifier.windowName === finsembleWindow.name) return FSBL.Clients.WindowClient.cancelTilingOrTabbing();
         FSBL.Clients.WindowClient.stopTilingOrTabbing({ allowDropOnSelf: true, action: "tabbing" }, () => {
-            console.log("Tab drag drop. post stop");
             FSBL.Clients.RouterClient.transmit("tabbingDragEnd", { success: true });
             if (identifier && identifier.windowName) {
                 //console.log("DROP", identifier);


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/106/cards/28710/details)

**Description of change**
* send a cancel from invalid drop zones

**Description of testing**
1. Tab dragging into top few pixels of window does not get stuck in tiling mode
1. tabbing, untabbing, reordering etc. works
